### PR TITLE
Make it work after /upgrade

### DIFF
--- a/himan.py
+++ b/himan.py
@@ -148,7 +148,9 @@ if __name__ == '__main__':
 
         init_options()
 
-        himan_buffer_create()
+        himan_buffer = w.buffer_search('python', 'himan')
+        if himan_buffer is None:
+            himan_buffer_create()
 
         w.hook_timer(2000, 0, 1, 'timer_cb', '[himan]\tHi, man!  What are they saying about you?\n'
                             '[himan]\tHighlights will be logged to "himan" buffer\n'


### PR DESCRIPTION
After running /upgrade, the script is reloaded, but the old buffer still
exists so a new one can't be created. This meant himan_buffer was set to
None which made the lines go to the core buffer instead. To fix this,
search for an existing buffer on startup and use that if it exists.